### PR TITLE
fix yaml issue

### DIFF
--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -28,7 +28,7 @@ If you are planning to use ssh handler plugin to induce failures against a speci
 ##Basic Usage
 Simoorg is started using the command *simoorg* which takes the path to your config directory as the only argument. Please check the config document ([link][docs/config.rst]) to better understand the configuration files.  The sample config directory packaged with the product can be used to set up your configs.  
 ```
-    Ex:     simoorg ~/configs/
+    Ex:     simoorg sample_configs/
 ```
 
 ##Usage Example

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -17,11 +17,11 @@ cd Simoorg
 ```
 When installing from the source, we recommend that you run all the unit and integration tests that are included with the source code, before starting the installations. You can do this by running the command
 ```
-    python setuptools.py test
+    sudo python setup.py test
 ```
 Once you have confirmed that the tests have passed, you can install the code by running the command
 ```
-    python setuptools.py install
+    sudo python setup.py install
 ```
 If you are planning to use ssh handler plugin to induce failures against a specific service cluster, please ensure that the user you are using to run simoorg have Passwordless SSH access to all the nodes in the cluster. You should also ensure that any failure scripts you plan to use are already present on all the nodes in the target service cluster.
 

--- a/sample_configs/plugins/topology/static/topo.yaml
+++ b/sample_configs/plugins/topology/static/topo.yaml
@@ -16,4 +16,4 @@
 # Static topology definition
 #
 topology:
-  nodes: ['test-node]
+  nodes: [test-node]


### PR DESCRIPTION
Fix the YMAL config.

When you do $ simoorg sample_configs/

[INFO]: Found moirai fate book  sample_service.yaml
[INFO]: Deploying atropos for: sample-service-name
sample-service-name 3019

API FIFO open for read

[2015-09-07 18:03:39.263919] [INFO]: Topology plugin initialized : StaticTopology
Process Process-1:
Traceback (most recent call last):
  File "/usr/lib64/python2.7/multiprocessing/process.py", line 258, in _bootstrap
    self.run()
  File "/usr/lib64/python2.7/multiprocessing/process.py", line 114, in run
    self._target(_self._args, *_self._kwargs)
  File "build/bdist.linux-x86_64/egg/simoorg/atropos.py", line 127, in __init__
    self.populate_topology()
  File "build/bdist.linux-x86_64/egg/simoorg/atropos.py", line 390, in populate_topology
    self.logger)
  File "build/bdist.linux-x86_64/egg/simoorg/plugins/topology/StaticTopology/StaticTopology.py", line 44, in **init**
    doc = yaml.load(file_desc)
  File "/usr/lib64/python2.7/dist-packages/yaml/**init**.py", line 71, in load
    return loader.get_single_data()
  File "/usr/lib64/python2.7/dist-packages/yaml/constructor.py", line 37, in get_single_data
    node = self.get_single_node()
  File "/usr/lib64/python2.7/dist-packages/yaml/composer.py", line 36, in get_single_node
    document = self.compose_document()
  File "/usr/lib64/python2.7/dist-packages/yaml/composer.py", line 55, in compose_document
    node = self.compose_node(None, None)
  File "/usr/lib64/python2.7/dist-packages/yaml/composer.py", line 84, in compose_node
    node = self.compose_mapping_node(anchor)
  File "/usr/lib64/python2.7/dist-packages/yaml/composer.py", line 133, in compose_mapping_node
    item_value = self.compose_node(node, item_key)
  File "/usr/lib64/python2.7/dist-packages/yaml/composer.py", line 84, in compose_node
    node = self.compose_mapping_node(anchor)
  File "/usr/lib64/python2.7/dist-packages/yaml/composer.py", line 133, in compose_mapping_node
    item_value = self.compose_node(node, item_key)
  File "/usr/lib64/python2.7/dist-packages/yaml/composer.py", line 82, in compose_node
    node = self.compose_sequence_node(anchor)
  File "/usr/lib64/python2.7/dist-packages/yaml/composer.py", line 110, in compose_sequence_node
    while not self.check_event(SequenceEndEvent):
  File "/usr/lib64/python2.7/dist-packages/yaml/parser.py", line 98, in check_event
    self.current_event = self.state()
  File "/usr/lib64/python2.7/dist-packages/yaml/parser.py", line 474, in parse_flow_sequence_first_entry
    return self.parse_flow_sequence_entry(first=True)
  File "/usr/lib64/python2.7/dist-packages/yaml/parser.py", line 477, in parse_flow_sequence_entry
    if not self.check_token(FlowSequenceEndToken):
  File "/usr/lib64/python2.7/dist-packages/yaml/scanner.py", line 116, in check_token
    self.fetch_more_tokens()
  File "/usr/lib64/python2.7/dist-packages/yaml/scanner.py", line 244, in fetch_more_tokens
    return self.fetch_single()
  File "/usr/lib64/python2.7/dist-packages/yaml/scanner.py", line 653, in fetch_single
    self.fetch_flow_scalar(style='\'')
  File "/usr/lib64/python2.7/dist-packages/yaml/scanner.py", line 667, in fetch_flow_scalar
    self.tokens.append(self.scan_flow_scalar(style))
  File "/usr/lib64/python2.7/dist-packages/yaml/scanner.py", line 1158, in scan_flow_scalar
    chunks.extend(self.scan_flow_scalar_spaces(double, start_mark))
  File "/usr/lib64/python2.7/dist-packages/yaml/scanner.py", line 1245, in scan_flow_scalar_spaces
    "found unexpected end of stream", self.get_mark())
ScannerError: while scanning a quoted scalar
  in "sample_configs/plugins/topology/static/topo.yaml", line 19, column 11
found unexpected end of stream
  in "sample_configs/plugins/topology/static/topo.yaml", line 20, column 1
[INFO]: Moirai shut down
Traceback (most recent call last):
  File "/usr/local/bin/simoorg", line 9, in <module>
    load_entry_point('simoorg==0.0.1', 'console_scripts', 'simoorg')()
  File "build/bdist.linux-x86_64/egg/pkg_resources/**init**.py", line 558, in load_entry_point

  File "build/bdist.linux-x86_64/egg/pkg_resources/**init**.py", line 2682, in load_entry_point

  File "build/bdist.linux-x86_64/egg/pkg_resources/**init**.py", line 2355, in load

  File "build/bdist.linux-x86_64/egg/pkg_resources/**init**.py", line 2365, in resolve

ImportError: 'module' object has no attribute 'main'
